### PR TITLE
Use `[patch.crates-io]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bundled = ["gdal/bundled"]
 pyo3 = { version = "0.22", features = ["extension-module", "abi3-py39"], optional = true }
 anyhow = "1.0.98"
 clap = { version = "4.5.38", features = ["derive"] }
-gdal = { git = "https://github.com/yutannihilation/gdal-rs", branch = "feat/expose-bundled-feature", features = ["bundled"] }
+gdal = "0.18"
 quick-xml = "0.37.5"
 rayon = "1.10.0"
 thiserror = "2.0.12"
@@ -47,3 +47,7 @@ tempfile = "3.20.0"
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# TODO: remove this when the pull request gets merged into the upstream
+[patch.crates-io]
+gdal = { git = "https://github.com/yutannihilation/gdal-rs", branch = "feat/expose-bundled-feature" }


### PR DESCRIPTION
これで、crates.io に publish するときは crates.io の gdal のバージョン、このレポジトリ上でビルドするときは `bundled` feature があるバージョン、になるはずです。

参考：https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html